### PR TITLE
Naprawa buga przy przełączaniu na kalendarz

### DIFF
--- a/Controls/CalendarNoUia.cs
+++ b/Controls/CalendarNoUia.cs
@@ -1,0 +1,16 @@
+﻿using System.Windows.Automation.Peers;
+using System.Windows.Controls;
+
+namespace PolMedUMG.Controls
+{
+    /// <summary>
+    /// Kalendarz bez obsługi UI-Automation 
+    /// zapobiega crashowania aplikacji po zmianie ustawienia
+    /// kontrolki w "umów wizytę" i przełączeniu na kalendarz
+    /// błąd prawdopodobnie związany z istniejącym zgłoszeniem https://github.com/dotnet/wpf/issues/8188
+    /// </summary>
+    public class CalendarNoUia : Calendar
+    {
+        protected override AutomationPeer OnCreateAutomationPeer() => null;
+    }
+}

--- a/View/Calendar.xaml
+++ b/View/Calendar.xaml
@@ -6,6 +6,8 @@
     xmlns:fa="clr-namespace:FontAwesome.WPF;assembly=FontAwesome.WPF"
     xmlns:System="clr-namespace:System;assembly=System.Runtime"
     xmlns:local="clr-namespace:PolMedUMG.ViewModel"
+    xmlns:ctrl="clr-namespace:PolMedUMG.Controls"
+
     xmlns:controls="clr-namespace:System.Windows.Controls;assembly=PresentationFramework"
     xml:lang="pl-PL"
     mc:Ignorable="d"
@@ -31,7 +33,7 @@
             </ItemsControl.ItemsPanel>
             <ItemsControl.ItemTemplate>
                 <DataTemplate>
-                    <Calendar CalendarItemStyle="{DynamicResource CalendarCalendarItemStyle1}"
+                    <ctrl:CalendarNoUia CalendarItemStyle="{DynamicResource CalendarCalendarItemStyle1}"
                           DisplayDateStart="{Binding .}"
                           DisplayMode="Month" 
                           Loaded="Calendar_Loaded"
@@ -40,15 +42,15 @@
                               Visibility="Collapsed"
                           BorderThickness="0" RenderTransformOrigin="0.5,0.5" FontSize="24">
 
-                        <Calendar.RenderTransform>
+                        <ctrl:CalendarNoUia.RenderTransform>
                             <TransformGroup>
                                 <ScaleTransform ScaleX="1.25" ScaleY="1.25"/>
                                 <SkewTransform/>
                                 <RotateTransform/>
                                 <TranslateTransform/>
                             </TransformGroup>
-                        </Calendar.RenderTransform>
-                    </Calendar>
+                        </ctrl:CalendarNoUia.RenderTransform>
+                    </ctrl:CalendarNoUia>
                 </DataTemplate>
             </ItemsControl.ItemTemplate>
         </ItemsControl>


### PR DESCRIPTION
Pzełączanie z kontrolki umów wizytę na kalendarz skutkowało crashowaniem aplikacji, błąd jest związany z UIElementAutomationPeer. Możliwa przyczyna - bląd w Microsoft WPF
